### PR TITLE
Reset the interventions filters when selecting another land use

### DIFF
--- a/javascript/dynamic-data.js
+++ b/javascript/dynamic-data.js
@@ -254,6 +254,7 @@ window.addEventListener('load', function () {
         element.addEventListener("click", function() {
           const slug = element.getAttribute('data-slug');
           window.mutations.setLandUse(slug);
+          window.mutations.setFilter(null);
           loadData(slug);
 
           element.setAttribute('aria-pressed', 'true');


### PR DESCRIPTION
This PR fixes an issue where the interventions filters of a land use are applied to another after switching to it.

## How to test

### Steps to reproduce

1. Open [Scientific Evidence](https://orcasa-review4c.vercel.app/)
2. Select the “Cropland” land use
3. Select the “Warming” and the “sub-type 1” interventions
4. Select the “Forest Land” land use
5. Open the list of publications

### Result

The sentence at the top of the list says:

> Showing 10 scientific publications and 6 meta-analyses related to sub-type 1 for cropland.

### Expected result

The sentence at the top of the list says:

> Showing 10 scientific publications and 6 meta-analyses related to forest land.

## Tracking

- [ORC-187](https://vizzuality.atlassian.net/browse/ORC-187)
- Fixes #15 

[ORC-187]: https://vizzuality.atlassian.net/browse/ORC-187?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ