### PR TITLE
Reset the filters and sorting when closing publications list

### DIFF
--- a/javascript/event-listeners.js
+++ b/javascript/event-listeners.js
@@ -1,4 +1,35 @@
 window.addEventListener('load', function () {
+  // SHARED CODE
+  const resetPublicationsFilters = () => {
+    for (let dropdown of elements.dropdowns) {
+      const selected = dropdown.querySelector('.dropdown-selected');
+      const options = dropdown.querySelector('.dropdown-options');
+      const inputs = options.querySelectorAll('input');
+
+      inputs.forEach(input => {
+        input.checked = false;
+      });
+
+      const placeholder = selected.attributes['aria-placeholder'].value;
+      selected.textContent = `${placeholder}`;
+
+      window.mutations.setPublicationFilters(dropdown.id, undefined);
+    }
+
+    window.mutations.setSearch('');
+    elements.search.querySelector('input').value = '';
+  };
+
+  const resetPublicationsSort = () => {
+    if (window.getters.publicationsSort() === 'desc') {
+      window.mutations.togglePublicationsSort();
+
+      const [text, icon] = elements.sortPublicationsButton.childNodes;
+      icon.classList.toggle('rotate-180');
+      text.textContent = 'Newest first';
+    }
+  };
+
   // LEGEND
 
   elements.legendToggle.addEventListener("click", function() {
@@ -155,6 +186,10 @@ window.addEventListener('load', function () {
   });
 
   elements.closePublicationPanelButton.addEventListener("click", function() {
+    // We reset the whole publications view without reloading the publications
+    resetPublicationsFilters();
+    resetPublicationsSort();
+
     window.mutations.setPublicationsOpen(false);
     elements.publicationPanel.classList.add('-translate-x-full');
 
@@ -351,28 +386,7 @@ window.addEventListener('load', function () {
 
   // RESET FILTERS
   elements.resetFiltersButton.addEventListener('click', () => {
-    window.mutations.setPublicationFilters('type-publication', ['meta-analysis', 'primary-paper']);
-    elements.typePublication.querySelectorAll('input').forEach(input => input.checked = true);
-
-    for (let dropdown of elements.dropdowns) {
-      const selected = dropdown.querySelector('.dropdown-selected');
-      const options = dropdown.querySelector('.dropdown-options');
-      const inputs = options.querySelectorAll('input');
-
-      inputs.forEach(input => {
-        input.checked = true;
-      });
-
-      const placeholder = selected.attributes['aria-placeholder'].value;
-      selected.textContent = `${placeholder} (${inputs.length})`;
-
-      const inputValues = [...inputs].map(input => input.value);
-      window.mutations.setPublicationFilters(dropdown.id, inputValues);
-    }
-
-    window.mutations.setSearch('');
-    elements.search.querySelector('input').value = '';
-
+    resetPublicationsFilters();
     window.reloadPublications();
   });
 


### PR DESCRIPTION
This PR resets all the filters and sorting of the publications list when it is closed.

## How to test

### Acceptance criteria

- When closing the publications list, all the publications filters are reset to their default state (i.e. non of them is active)
- When closing the publications list, the sorting option is reset (i.e. newest first)

## Tracking

- [ORC-188](https://vizzuality.atlassian.net/browse/ORC-188)
- Fixes #12 

[ORC-188]: https://vizzuality.atlassian.net/browse/ORC-188?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ