### PR TITLE
Remove a hard-coded land use name from the legend

### DIFF
--- a/index.html
+++ b/index.html
@@ -512,8 +512,7 @@
             class="h-9 pt-3 pb-1 border-t border-gray-300 border-dashed items-center gap-2 flex w-full">
             <div class="w-4 h-4 bg-slate-700"></div>
             <div class="inline text-slate-700 text-sm leading-tight">
-              <span>Cropland
-                publications </span>
+              <span>Publications </span>
               <span
                 class="font-semibold">by
                 country</span>


### PR DESCRIPTION
This PR replaces the hard-coded “Cropland publications by country” text from the legend by “Publications by country”. The name of the land use is not necessary anymore as it already appears in the legend's title.

## How to test

### Steps to reproduce

1. Open [Scientific Evidence](https://orcasa-review4c.vercel.app/)

### Result

The legend says:

> Cropland publications by country

### Expected result

The legend says:

> Publications by country

### Acceptance criteria

- Independently from which land use is selected, the legend always says « Publications by country »
  - Note: the name of the land use already appears as the title of the legend

## Tracking

[ORC-190](https://vizzuality.atlassian.net/browse/ORC-190)

[ORC-190]: https://vizzuality.atlassian.net/browse/ORC-190?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ