### PR TITLE
Fix incorrect pagination parameter for the publications list request

### DIFF
--- a/javascript/document-elements.js
+++ b/javascript/document-elements.js
@@ -27,7 +27,6 @@ const elements = {
   publicationDetailModal: document.getElementById('publication-detail-modal'),
   publicationDetailPanelContent: document.getElementById('publication-detail-panel-content'),
   closePublicationDetailPanelButton: document.getElementById('btn-close-publication-detail-panel'),
-  closePublicationDetailPanelButton: document.getElementById('btn-close-publication-detail-panel'),
   landUseMenu: document.getElementById('land-use-menu'),
   landUseText: document.getElementById('land-use-text'),
   landUseIntro: document.getElementById('land-use-intro'),

--- a/javascript/event-listeners.js
+++ b/javascript/event-listeners.js
@@ -190,6 +190,9 @@ window.addEventListener('load', function () {
     resetPublicationsFilters();
     resetPublicationsSort();
 
+    // We reset the pagination
+    window.mutations.setPublicationPage(1);
+
     window.mutations.setPublicationsOpen(false);
     elements.publicationPanel.classList.add('-translate-x-full');
 


### PR DESCRIPTION
This PR fixes an issue where an incorrect pagination parameter would be passed to the publications list request after the user has loaded several pages of results.

## How to test

### Steps to reproduce

1. Open [Scientific Evidence](https://orcasa-review4c.vercel.app/)
2. Open the list of publications
3. Scroll to the bottom of the list
4. Click “Go back”
5. Re-open the list of publications

### Result

The request that fetches the list of publications contains the following parameter: `page=2`.

### Expected result

The request should contain the following parameter instead: `page=1`.

## Tracking

- [ORC-200](https://vizzuality.atlassian.net/browse/ORC-200)
- Fixes #23 

[ORC-200]: https://vizzuality.atlassian.net/browse/ORC-200?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ