### PR TITLE
Support publications without associated journals nor countries

### DIFF
--- a/javascript/api-service.js
+++ b/javascript/api-service.js
@@ -79,9 +79,9 @@ const getPublications = async ({ landUse, mainIntervention, intervention, subTyp
         const { countryIsos, year, journalIds } = publication;
         const { country: countrySelection, year: yearSelection, journal: journalSelection, 'type-publication': typeSelection } = publicationFilters;
 
-        const countryFilter = countrySelection?.length ? countrySelection.some(iso => countryIsos.includes(iso)) : true;
+        const countryFilter = countrySelection?.length && countryIsos.length > 0 ? countrySelection.some(iso => countryIsos.includes(iso)) : true;
         const yearFilter = yearSelection?.length ? yearSelection.includes(String(year)) : true;
-        const journalFilter = journalSelection?.length ? journalSelection.some(jID => journalIds.map(String).includes(jID)) : true;
+        const journalFilter = journalSelection?.length && journalIds.length > 0 ? journalSelection.some(jID => journalIds.map(String).includes(jID)) : true;
         const typePublicationFilter = typeSelection?.length ? typeSelection.includes(publication.type) : true;
         return countryFilter && yearFilter && journalFilter && typePublicationFilter;
       });

--- a/javascript/dynamic-data.js
+++ b/javascript/dynamic-data.js
@@ -60,7 +60,7 @@ const publicationCardTemplate = ({ isDetail = false, isMetaAnalysis, journals, y
     </div>
     </div>` : ''}
     <div class="w-full h-6 gap-4 flex text-slate-500 text-xs">
-        ${!isMetaAnalysis ? `<div class="justify-start items-center gap-2 flex max-w-[60%] w-fit">
+        ${!isMetaAnalysis && journals.length > 0 ? `<div class="justify-start items-center gap-2 flex max-w-[60%] w-fit">
           <i data-lucide="newspaper" class="w-6 h-6 relative"></i>
           <div class="flex-1 truncate" title="${journals.join(', ')}">${journals.join(', ')}</div>
         </div>`: ''}
@@ -68,7 +68,7 @@ const publicationCardTemplate = ({ isDetail = false, isMetaAnalysis, journals, y
           <i data-lucide="calendar" class="w-6 h-6 relative max-width-[10%]"></i>
           <div>${year}</div>
         </div>
-        ${!isMetaAnalysis ? `<div class="justify-start items-center gap-2 flex max-w-[30%]">
+        ${!isMetaAnalysis && countries.length > 0 ? `<div class="justify-start items-center gap-2 flex max-w-[30%]">
           <i data-lucide="globe-2" class="w-6 h-6 relative"></i>
           <div class="truncate" title="${countries.join(', ')}">${countries.join(', ')}</div>
         </div>` : ''}

--- a/javascript/dynamic-data.js
+++ b/javascript/dynamic-data.js
@@ -54,7 +54,7 @@ const publicationCardTemplate = ({ isDetail = false, isMetaAnalysis, journals, y
     </div>
   </div>` : ''}
   <div class="h-6 justify-start items-center gap-6 inline-flex">
-  ${isDetail && isMetaAnalysis ? `<div class="flex">
+  ${isDetail && isMetaAnalysis ? `<div class="flex flex-shrink-0">
     <div class="px-2 text-white text-base px-2 bg-teal-500 rounded border border-teal-500">
       Meta-analysis
     </div>

--- a/mocks/data/publications/index.json
+++ b/mocks/data/publications/index.json
@@ -2,16 +2,9 @@
   {
       "id": 1,
       "title": "Advances in Crop Management Techniques",
-      "journalIds": [
-          78,
-          16
-      ],
+      "journalIds": [],
       "year": 2018,
-      "countryIsos": [
-          "ES",
-          "PT",
-          "FR"
-      ],
+      "countryIsos": [],
       "type": "meta-analysis",
       "authors": "Smith, John; Brown, Emily; Wilson, David",
       "url": "http://example.com/advances-in-agronomy",
@@ -30,14 +23,9 @@
   {
       "id": 2,
       "title": "Emission of CO2 from biochar-amended soils and implications for soil organic carbon",
-      "journalIds": [
-          67,
-          16
-      ],
+      "journalIds": [],
       "year": 2013,
-      "countryIsos": [
-          "PT"
-      ],
+      "countryIsos": [],
       "type": "primary-paper",
       "authors": "Woolf, Dominic; Amonette, James E.; Street-Perrott, F. Alayne; Lehmann, Johannes; Joseph, Stephen",
       "url": "http://onlinelibrary.wiley.com/doi/10.1111/gcbb.12044/abstract",


### PR DESCRIPTION
This PR changes the publications list and detailed view to support publications that are not associated with journals nor countries.

## How to test

I updated two mock publications:

- « Advances in Crop Management Techniques » (meta-analysis)
- « Emission of CO2 from biochar-amended soils and implications for soil organic carbon » (primary publication)

You can use them to test the acceptance criteria below.

### Acceptance criteria

- Primary publication
  - If a primary publication isn’t associated with a country:
    - The country field is hidden from the list and detail views
    - When filtering by country, the publication is always visible
  - If a primary publication isn’t associated with a journal:
    - The field is hidden from the list and detail views
    - When filtering by journal, the publication is always visible
- Meta analysis
  - If a meta analysis isn’t associated with a country:
    - When filtering by country, the publication is always visible
  - If a meta analysis isn’t associated with a journal:
    - When filtering by country, the publication is always visible

## Tracking

- [ORC-191](https://vizzuality.atlassian.net/browse/ORC-191)
- Fixes #18 

[ORC-191]: https://vizzuality.atlassian.net/browse/ORC-191?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ