### PR TITLE
Use a standardised format for the numbers

### DIFF
--- a/javascript/d3-chart.js
+++ b/javascript/d3-chart.js
@@ -194,8 +194,8 @@ const createSVGChart = (slug, data) => {
     .tickFormat(() => '');
 
   const buttonHTML = (title, publications, slug) =>
-    `<button type="button" class="btn-filter-chart mt-0.5 max-w-[${yTickWidth}px]" aria-pressed="false" id="btn-${kebabCase(slug)}" title="${title} (${publications})">
-      <span class="mr-1.5 overflow-hidden whitespace-nowrap text-ellipsis">${title}</span><span class="text-xs shrink-0">(${publications})</span>
+    `<button type="button" class="btn-filter-chart mt-0.5 max-w-[${yTickWidth}px]" aria-pressed="false" id="btn-${kebabCase(slug)}" title="${title} (${formatNumber(publications)})">
+      <span class="mr-1.5 overflow-hidden whitespace-nowrap text-ellipsis">${title}</span><span class="text-xs shrink-0">(${formatNumber(publications)})</span>
     </button>`;
   ;
 

--- a/javascript/dynamic-data.js
+++ b/javascript/dynamic-data.js
@@ -163,8 +163,8 @@ window.addEventListener('load', function () {
     addLayer(map, slug);
 
     // Update the description with the land use publications and meta-analysis
-    const publicationsNumber = publications?.toLocaleString() || '-';
-    const metaAnalysisNumber = metaAnalysis?.toLocaleString() || '-';
+    const publicationsNumber = formatNumber(publications) || '-';
+    const metaAnalysisNumber = formatNumber(metaAnalysis) || '-';
     if (landUseSlug === 'all') {
       elements.landUseIntro.innerHTML = `<div class="space-y-6">
         <div class="text-slate-700 text-[32px] leading-[48px]">
@@ -228,7 +228,7 @@ window.addEventListener('load', function () {
       ${name}
     </span>
     <span class="text-xs">
-    (${publications?.toLocaleString()})
+    (${formatNumber(publications)})
     </span>
     </button>
   `;
@@ -333,8 +333,8 @@ window.addEventListener('load', function () {
       }
     }
 
-    elements.metaAnalysisNumber.innerHTML = totalMetaAnalysis || 0;
-    elements.publicationsNumber.innerHTML = totalPublications || 0;
+    elements.metaAnalysisNumber.innerHTML = formatNumber(totalMetaAnalysis) || 0;
+    elements.publicationsNumber.innerHTML = formatNumber(totalPublications) || 0;
 
     elements.filtersSelectionText.innerHTML = selection;
   };

--- a/javascript/event-listeners.js
+++ b/javascript/event-listeners.js
@@ -313,7 +313,7 @@ window.addEventListener('load', function () {
         selected.textContent = placeholder;
         window.mutations.setPublicationFilters(dropdown.id, []);
       } else {
-        selected.textContent = `${placeholder} (${selectedLabels.length})`;
+        selected.textContent = `${placeholder} (${formatNumber(selectedLabels.length)})`;
         window.mutations.setPublicationFilters(dropdown.id, selectedValues);
       };
 
@@ -329,7 +329,7 @@ window.addEventListener('load', function () {
       });
 
       const placeholder = selected.attributes['aria-placeholder'].value;
-      selected.textContent = `${placeholder} (${inputs.length})`;
+      selected.textContent = `${placeholder} (${formatNumber(inputs.length)})`;
 
       const inputValues = [...inputs].map(input => input.value);
       window.mutations.setPublicationFilters(dropdown.id, inputValues);

--- a/javascript/utils.js
+++ b/javascript/utils.js
@@ -21,3 +21,10 @@ const ellipsis = (text, length) => {
 }
 
 const uniq = (arr) => [...new Set(arr)];
+
+const formatNumber = (value) => {
+  // The French number format uses spaces to separate thousands, millions, etc. and a comma to
+  // separate the decimals e.g. 1 456 357,45
+  const formatter = Intl.NumberFormat('fr');
+  return formatter.format(value);
+};

--- a/mocks/data/charts/cropland/climate-change/index.json
+++ b/mocks/data/charts/cropland/climate-change/index.json
@@ -35,7 +35,7 @@
             "value": 11.43,
             "low": -23.65,
             "high": 31.23,
-            "publications": 512,
+            "publications": 5712,
             "subTypes": [
                 {
                     "title": "sub-type 1",


### PR DESCRIPTION
This PR uses a standardised format for all the numbers e.g. 1 543,56.

## How to test

You can check the acceptance criteria below.

### Acceptance criteria

- All the numbers of the platform use an international format
  - Format:
    - Use a space as a group separator e.g. 1 456 357
    - Use a comma as a decimal separator e.g. 1,45
  - Applies to the following numbers:
    - Number of publications next to the land use tabs
    - Number of publications inside the sentence of each land use
    - Number of publications in the infographic of the “All” land use
    - Number of publications in the intervention charts
    - Number of publications on the map
    - Number of publications in the map’s tooltip
    - Number of publications in the sentence at the top of the publications list
    - Number of selected values for each publication filter

## Tracking

- [ORC-192](https://vizzuality.atlassian.net/browse/ORC-192)
- Fixes #17 

[ORC-192]: https://vizzuality.atlassian.net/browse/ORC-192?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ