### PR TITLE
Fix bug where the publication type filter would trigger two requests

### DIFF
--- a/index.html
+++ b/index.html
@@ -294,7 +294,7 @@
               </button>
               <div id="type-publication">
                 <label for="type-publication"
-                  class="sr-only">type-publication</label>
+                  class="sr-only">Publication type</label>
                 <div
                   class="relative dropdown h-14 flex-col flex"
                   id="dropdown-select-type-publication">
@@ -302,7 +302,7 @@
                     type="button"
                     class="btn-dropdown p-4 bg-white shadow border border-gray-400 flex justify-between focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-mod-sc-ev">
                     <span
-                      id="type-pubication-selected"
+                      id="type-publication-selected"
                       aria-placeholder="Publication type"
                       class="dropdown-selected text-slate-700">Publication type
                     </span>

--- a/javascript/event-listeners.js
+++ b/javascript/event-listeners.js
@@ -360,25 +360,6 @@ window.addEventListener('load', function () {
     });
   }
 
-  // PUBLICATION TYPE CHECKBOXES
-  elements.typePublication.addEventListener('click', ({ target }) => {
-    if (target.type !== 'checkbox') {
-      return;
-    }
-
-    const selectedValues = [];
-
-    elements.typePublication.querySelectorAll('input').forEach(input => {
-      if (input.checked) {
-        selectedValues.push(input.value);
-      }
-    });
-    window.mutations.setPublicationFilters('type-publication', selectedValues);
-
-    // Reload publications
-    window.reloadPublications();
-  });
-
   // SEARCH
   elements.search.addEventListener('input', debounce(() => {
       const searchInput = elements.search.querySelector('input');


### PR DESCRIPTION
This PR fixes a bug where the publication type filter would trigger two requests when the user would select a value.

## How to test

### Steps to reproduce

1. Open [Scientific Evidence](https://orcasa-review4c.vercel.app/)
2. Select the “Cropland” land use
3. Open the list of publications
4. Filter by “Primary paper”

### Result

Two requests are made to load the publications list.

### Expected result

Only one request is made to load the publications list.

## Tracking

- [ORC-193](https://vizzuality.atlassian.net/browse/ORC-193)
- Fixes #11 