### PR TITLE
Prevent the user from inadvertently reseting all the filters

### DIFF
--- a/index.html
+++ b/index.html
@@ -288,8 +288,7 @@
               </div>
             </div>
             <div class="flex flex-col gap-6">
-              <button type="button" id="reset-filters"
-                class="btn-light">
+              <button type="button" id="reset-filters" class="btn-light w-min whitespace-nowrap">
                 Reset All
               </button>
               <div id="type-publication">


### PR DESCRIPTION
This PR changes the size of the “Reset all” button so that the user cannot inadvertently click on it.

## How to test

### Steps to reproduce

1. Open [Scientific Evidence](https://orcasa-review4c.vercel.app/)
2. Open the list of publications
3. Click on the far right of the “Reset all” button

### Result

The button is clicked.

### Expected result

The button is _not_ clicked i.e. the button should only be clicked if the user clicks on the text.

## Tracking

- [ORC-196](https://vizzuality.atlassian.net/browse/ORC-196)
- Fixes #13 

[ORC-196]: https://vizzuality.atlassian.net/browse/ORC-196?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ