### PR TITLE
Fix a bug where duplicated clusters would appear on the map

### DIFF
--- a/javascript/map/map-layers.js
+++ b/javascript/map/map-layers.js
@@ -1,11 +1,18 @@
 const addLayer = (map, landUseSlug="all", mainInterventionSlug, interventionSlug, subTypeSlug) => {
-  const layerSlug = landUseSlug === 'all' ? 'all' : `${landUseSlug}${mainInterventionSlug ? `-${mainInterventionSlug}` : ''}${interventionSlug ? `-${interventionSlug}` : ''}${subTypeSlug ? `-${subTypeSlug}` : ''}`;
+  const slug = landUseSlug === 'all'
+    ? landUseSlug
+    : [landUseSlug, mainInterventionSlug, interventionSlug, subTypeSlug].filter(Boolean).join('-');
+  const layerName = `layer-${slug}`;
+  const clusterLayerName = `clusters-${slug}`;
+
   const currentLayers = map.getStyle()?.layers;
   const currentSources = map.getStyle()?.sources;
-  const layerName = `layer-${layerSlug}`;
+
+  const isSourceDefined = !!currentSources[layerName];
+  const isLayerActive = currentLayers.some(l => l.id === layerName);
 
   // Get the layer and load it if not already loaded
-  if (!currentSources[layerName] || !currentLayers.find(l => l.id === layerName)) {
+  if (!isSourceDefined || !isLayerActive) {
     getLayer(landUseSlug, mainInterventionSlug, interventionSlug, subTypeSlug).then(layer => {
       const countryValues = layer && Object.values(layer);
       const features = countryValues && countryValues.map(country => {
@@ -24,10 +31,10 @@ const addLayer = (map, landUseSlug="all", mainInterventionSlug, interventionSlug
 
       const geoJSONContent = {
         type: 'FeatureCollection',
-        features: features,
+        features,
       };
 
-      if (!currentSources[layerName]) {
+      if (!isSourceDefined) {
         // ADD SOURCE. SAME FOR CLUSTERS AND LAYER
         map.addSource(layerName, {
           'type': 'geojson',
@@ -41,11 +48,10 @@ const addLayer = (map, landUseSlug="all", mainInterventionSlug, interventionSlug
         });
       }
 
-      if (!currentLayers.find(l => l.id === layerName)) {
-
+      if (!isLayerActive) {
         // ADD CLUSTERS
         map.addLayer({
-          id: `clusters-${layerName}`,
+          id: clusterLayerName,
           type: 'symbol',
           source: layerName,
           filter: ['has', 'point_count'],
@@ -119,9 +125,9 @@ const addLayer = (map, landUseSlug="all", mainInterventionSlug, interventionSlug
         });
 
         // Clusters zoom on click
-        map.on('click', `clusters-${layerName}`, (e) => {
+        map.on('click', clusterLayerName, (e) => {
           const features = map.queryRenderedFeatures(e.point, {
-            layers: [`clusters-${layerName}`]
+            layers: [clusterLayerName]
           });
           const clusterId = features[0].properties.cluster_id;
           const leftPadding = elements.sidebar.getBoundingClientRect().right;
@@ -183,18 +189,14 @@ const addLayer = (map, landUseSlug="all", mainInterventionSlug, interventionSlug
     });
   }
 
-  currentLayers.forEach(layer => {
-    const layerId = layer.id;
-    const selectedLayerId = `layer-${layerSlug}`;
-    if (
-      layerId.startsWith('layer-') && layerId !== selectedLayerId ||
-      layerId.startsWith('clusters-') && !layerId.startsWith(`clusters-${selectedLayerId}`)
+  currentLayers.forEach(({ id }) => {
+    if (id === layerName || id === clusterLayerName) {
+      map.setLayoutProperty(id, 'visibility', 'visible');
+    } else if (
+      id.startsWith('layer-') && id !== layerName ||
+      id.startsWith('clusters-') && id !== clusterLayerName
     ) {
-      map.setLayoutProperty(layerId, 'visibility', 'none');
-    }
-
-    if (layerId === selectedLayerId || layerId === `clusters-${selectedLayerId}`) {
-      map.setLayoutProperty(layerId, 'visibility', 'visible');
+      map.setLayoutProperty(id, 'visibility', 'none');
     }
   });
 };


### PR DESCRIPTION
This PR fixes an issue where duplicated clusters could appear on the map after applying and removing an intervention filter.

## How to test

### Steps to reproduce

1. Open [Scientific Evidence](https://orcasa-review4c.vercel.app/)
2. Select the “Cropland” land use
  a. Notice the number of markers on top of western Europe
4. Select the “Warming” intervention
  a. Deselect the “Warming” intervention

Notice the number of markers on top of western Europe

### Result

Before selecting “Warming”, the number of markers on top of western Europe is 13 397. After deselecting, it is 13 397 and an additional 4 041.

### Expected result

Before selecting “Warming”, the number of markers on top of western Europe is 13 397. After deselecting, it is also 13 397.

## Tracking

- [ORC-209](https://vizzuality.atlassian.net/browse/ORC-209)
- Fixes #22 

[ORC-209]: https://vizzuality.atlassian.net/browse/ORC-209?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ