### PR TITLE
Fix non-working “Learn more” button in the detailed view

### DIFF
--- a/javascript/dynamic-data.js
+++ b/javascript/dynamic-data.js
@@ -456,6 +456,16 @@ window.addEventListener('load', function () {
     window.loadPublication(publicationId);
   };
 
+  const addListenerToPublicationButton = function() {
+    for (let link of elements.publicationDetailButton) {
+      // We remove any previous event listener to avoid loading twice the publication. This
+      // happens after scrolling since this function is called to add new publication at the
+      // bottom of the list.
+      link.removeEventListener('click', onOpenPublication);
+      link.addEventListener("click", onOpenPublication);
+    }
+  };
+
   window.loadPublications = (reload, addNewPage) => {
     if (reload && !addNewPage) {
       // Go to page 1 of the new selection
@@ -491,13 +501,7 @@ window.addEventListener('load', function () {
         elements.publicationsContainer.appendChild(createPublicationCard(publication));
       });
 
-      for (let link of elements.publicationDetailButton) {
-        // We remove any previous event listener to avoid loading twice the publication. This
-        // happens after scrolling since this function is called to add new publication at the
-        // bottom of the list.
-        link.removeEventListener('click', onOpenPublication);
-        link.addEventListener("click", onOpenPublication);
-      }
+      addListenerToPublicationButton();
 
       if(!reload) {
         populateYearChart(metadata.years);
@@ -549,6 +553,8 @@ window.addEventListener('load', function () {
         metaAnalysis,
       });
       elements.publicationDetailPanelContent.appendChild(card);
+
+      addListenerToPublicationButton();
 
       // Update lucide icons
       lucide.createIcons();


### PR DESCRIPTION
This PR fixes an issue where the user could not access a meta-analysis through the detailed view of a primary publication because the button was missing an event handler.

## How to test

1. Open [Scientific Evidence](https://orcasa-review4c.vercel.app/)
2. Open the list of publications
3. Open a primary publication
4. Click the “Learn more” button of the associated meta-analysis

### Result

Nothing happens.

### Expected result

The modal shows the details of the meta-analysis.

## Tracking

- [ORC-210](https://vizzuality.atlassian.net/browse/ORC-210)
- Fixes #26 

[ORC-210]: https://vizzuality.atlassian.net/browse/ORC-210?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ