### PR TITLE
Update the styles of the clusters, markers and legend

### DIFF
--- a/index.html
+++ b/index.html
@@ -787,9 +787,16 @@
         .maplibregl-ctrl-group button+button {
           @apply border-gray-300;
         }
+        .maplibregl-popup {
+          @apply !max-w-none;
+        }
 
         .maplibregl-popup-content {
-          @apply z-50 w-[365px] h-[214px] flex max-w-[300px] p-4 rounded backdrop-blur-sm flex-col gap-4;
+          @apply z-50 w-[400px] h-[240px] p-6 overflow-hidden rounded-none backdrop-blur-sm;
+        }
+
+        .maplibregl-popup-tip {
+          @apply !hidden;
         }
       }
     </style>

--- a/index.html
+++ b/index.html
@@ -26,6 +26,7 @@
     <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.min.js"></script>
     <!-- Map -->
     <script src="https://unpkg.com/maplibre-gl@%5E3.3.0/dist/maplibre-gl.js"></script>
+    <script src="https://unpkg.com/supercluster@8.0.1/dist/supercluster.min.js"></script>
     <link href='https://unpkg.com/maplibre-gl@3.3.0/dist/maplibre-gl.css'
       rel='stylesheet' />
 
@@ -527,12 +528,12 @@
                   <span class="mr-3 w-full border-t border-dashed border-gray-200"></span>
                 </div>
                 <div class="-mt-px flex h-[21px] w-full items-center text-right">
-                  <span class="mr-[10px] w-[60px]">100-500</span>
+                  <span class="mr-[10px] w-[60px]">10-500</span>
                   <span class="h-[6px] w-[8px] rotate-45 bg-gray-200 p-0"></span>
                   <span class="mr-3 w-full border-t border-dashed border-gray-200"></span>
                 </div>
                 <div class="-mt-px flex h-[21px] w-full items-center text-right">
-                  <span class="mr-[10px] w-[60px]">1-100</span>
+                  <span class="mr-[10px] w-[60px]">1-10</span>
                   <span class="h-1.5 w-2 rotate-45 bg-gray-200 p-0"></span>
                   <span class="mr-3 w-full border-t border-dashed border-gray-200"></span>
                 </div>

--- a/index.html
+++ b/index.html
@@ -495,57 +495,72 @@
     </div>
 
     <!-- LEGEND -->
-    <div class="absolute bottom-9 right-6">
-      <div class="absolute -ml-px -top-10 right-0">
-        <button id="legend-toggle"
-          class="btn-icon-theme-dark">
-          <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
-            viewBox="0 0 24 24" fill="none" stroke="currentColor"
-            stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
-            class="h-6 w-6 transition-transform -rotate-90"><polyline
-              points="15 18 9 12 15 6"></polyline></svg></button>
+    <div class="absolute bottom-16 right-6 z-10">
+      <div class="absolute -ml-px bottom-full right-0">
+        <button id="legend-toggle" class="btn-theme-dark text-xs px-2 py-1 whitespace-nowrap">
+          Hide legend
+        </button>
       </div>
       <div
         id="legend"
-        class="w-[328px] p-2 bg-white shadow transition-transform overflow-hidden">
-        <div
-          class="text-base font-semibold mb-2"><span
-            class="font-semibold" id="legend-text"></span>
-          publications</div>
-        <div
-          class="flex flex-col justify-center items-end gap-1">
-          <div class="text-slate-500 text-xs leading-[18px]">
-            sum of publications
+        class="w-[328px] p-3 bg-white shadow transition-transform"
+      >
+        <div class="text-base font-semibold mb-2">
+          <span class="font-semibold legend-text"></span>
+          publications
+        </div>
+        <div class="flex flex-col gap-3">
+          <div class="flex items-center justify-start gap-1 text-sm text-slate-500">
+            Sum of publications.
           </div>
-          <div
-            class="flex w-full justify-between h-4">
-            <div class="flex-1 bg-cluster-100"></div>
-            <div class="flex-1 bg-cluster-200"></div>
-            <div class="flex-1 bg-cluster-300"></div>
-            <div class="flex-1 bg-cluster-400"></div>
-            <div class="flex-1 bg-cluster-500"></div>
+          <div class="flex justify-end">
+            <div class="relative h-20 w-[274px] text-xs text-slate-500">
+              <div class="flex flex-col">
+                <div class="-mt-px flex h-[21px] w-full items-center text-right">
+                  <span class="mr-[10px] w-[60px]">&gt;5k</span>
+                  <span class="h-[6px] w-[8px] rotate-45 bg-gray-200 p-0"></span>
+                  <span class="mr-3 w-full border-t border-dashed border-gray-200"></span>
+                </div>
+                <div class="-mt-px flex h-[21px] w-full items-center text-right">
+                  <span class="mr-[10px] w-[60px]">500-5k</span>
+                  <span class="h-[6px] w-[8px] rotate-45 bg-gray-200 p-0"></span>
+                  <span class="mr-3 w-full border-t border-dashed border-gray-200"></span>
+                </div>
+                <div class="-mt-px flex h-[21px] w-full items-center text-right">
+                  <span class="mr-[10px] w-[60px]">100-500</span>
+                  <span class="h-[6px] w-[8px] rotate-45 bg-gray-200 p-0"></span>
+                  <span class="mr-3 w-full border-t border-dashed border-gray-200"></span>
+                </div>
+                <div class="-mt-px flex h-[21px] w-full items-center text-right">
+                  <span class="mr-[10px] w-[60px]">1-100</span>
+                  <span class="h-1.5 w-2 rotate-45 bg-gray-200 p-0"></span>
+                  <span class="mr-3 w-full border-t border-dashed border-gray-200"></span>
+                </div>
+              </div>
+              <div class="absolute right-3 top-0">
+                <div class="absolute right-0 top-[70px] h-5 w-5 border border-gray-200"></div>
+                <div class="absolute right-0 top-[50px] h-10 w-10 border border-gray-200"></div>
+                <div class="absolute right-0 top-[30px] h-[60px] w-[60px] border border-gray-200"></div>
+                <div class="absolute right-0 top-[10px] h-20 w-20 border border-gray-200"></div>
+              </div>
+            </div>
           </div>
-          <div
-            class="flex w-full justify-between h-4 text-slate-500 text-xs text-center leading-[18px]">
-            <div
-              class="text-center flex-1">1-100</div>
-            <div
-              class="text-center flex-1">100-500</div>
-            <div
-              class="text-center flex-1">500-1k</div>
-            <div
-              class="text-center flex-1">1-5k</div>
-            <div
-              class="text-center flex-1">>5k</div>
+          <div class="flex items-center gap-2 border-t border-gray-100 pb-1 pt-3">
+            <div class="border-2 border-mod-sc-ev">
+              <div class="flex h-3 w-3 bg-mod-sc-ev"></div>
+            </div>
+            <div class="text-sm text-slate-700">
+              <span class="legend-text"></span>
+              publications
+            </div>
           </div>
-          <div
-            class="h-9 pt-3 pb-1 border-t border-gray-300 border-dashed items-center gap-2 flex w-full">
-            <div class="w-4 h-4 bg-slate-700"></div>
-            <div class="inline text-slate-700 text-sm leading-tight">
-              <span>Publications </span>
-              <span
-                class="font-semibold">by
-                country</span>
+          <div class="flex items-center gap-2 border-t border-gray-100 pb-1 pt-3">
+            <div class="border-2 border-slate-700">
+              <div class="flex h-3 w-3 bg-mod-sc-ev"></div>
+            </div>
+            <div class="text-sm text-slate-700">
+              <span class="legend-text"></span>
+              publications by country
             </div>
           </div>
         </div>

--- a/javascript/document-elements.js
+++ b/javascript/document-elements.js
@@ -35,7 +35,7 @@ const elements = {
   publicationsNumber: document.getElementById('publications-number'),
   metaAnalysisNumber: document.getElementById('meta-analysis-number'),
   filtersSelectionText: document.getElementById('filters-selection-text'),
-  legendText: document.getElementById('legend-text'),
+  legendTexts: document.querySelectorAll('.legend-text'),
   chartCards: document.getElementById('chart-cards'),
   sortPublicationsButton: document.getElementById('btn-sort-publications'),
   publicationsContainer: document.getElementById('publications-container'),

--- a/javascript/dynamic-data.js
+++ b/javascript/dynamic-data.js
@@ -220,7 +220,7 @@ window.addEventListener('load', function () {
       </div>`;
       elements.landUseAllIntro.innerHTML = '';
     }
-    elements.legendText.innerHTML = name;
+    Array.from(elements.legendTexts).map(text => text.innerHTML = name);
 
     // Load main intervention charts
     if (landUse.mainInterventions) {

--- a/javascript/event-listeners.js
+++ b/javascript/event-listeners.js
@@ -35,11 +35,11 @@ window.addEventListener('load', function () {
   elements.legendToggle.addEventListener("click", function() {
     window.mutations.toggleLegend();
     if (!state.legendOpen) {
-      elements.legend.classList.add('h-9');
-      elements.legendToggle.classList.add('rotate-180');
+      elements.legend.classList.add('hidden');
+      elements.legendToggle.innerHTML = 'Show legend';
     } else {
-      elements.legend.classList.remove('h-9');
-      elements.legendToggle.classList.remove('rotate-180');
+      elements.legend.classList.remove('hidden');
+      elements.legendToggle.innerHTML = 'Hide legend';
     }
   });
 

--- a/javascript/map/map-layers.js
+++ b/javascript/map/map-layers.js
@@ -45,26 +45,27 @@ const getHTMLPopup = (feature) => {
     .sort((a, b) => b[1] - a[1])
     .map(([key, value]) => (`
       <span class="text-right">${formatNumber(value)}</span>
-      <span>${key}</span>
+      <span class="font-semibold text-mod-sc-ev">${key}</span>
     `)).join('');
 
   return `
-    <div class="space-y-4">
-      <h4 class="text-slate-700 text-xl font-semibold font-serif leading-[30px]">
-        ${country_name}
+    <div class="h-full flex flex-col gap-y-4">
+      <h4 class="shrink-0 text-slate-700 text-lg font-serif">
+        Publications in ${country_name}
       </h4>
-      <button type="button" id="popup-close-button" class="absolute right-4 top-4 !m-0">
+      <button type="button" id="popup-close-button" class="shrink-0 inline-flex items-center justify-center text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 font-sans bg-gray-700 hover:bg-gray-500 text-white h-10 w-10 absolute right-0 top-0">
         <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor"
           stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="h-6 w-6">
           <path d="M18 6 6 18"></path>
           <path d="m6 6 12 12"></path>
         </svg>
-        <span class="sr-only">Close</span>
+        <span class="sr-only">Close popup</span>
       </button>
-      <div class="max-h-[140px] overflow-y-auto overflow-x-hidden">
+      <div class="grow overflow-y-auto overflow-x-hidden font-sans text-base">
         <div class="grid grid-cols-[min-content_1fr] auto-rows-auto gap-x-2 w-full">
-          <span class="mb-3">${formatNumber(number_primary_studies)}</span>
-          <span class="mb-3">total</span>
+          <span class="mb-6">${formatNumber(number_primary_studies)}</span>
+          <span class="mb-6 font-semibold text-mod-sc-ev">total</span>
+          <hr class="col-span-2 mb-4 border-dashed border-gray-200 h-0" />
           ${outcomesList}
         </div>
       </div>
@@ -136,7 +137,7 @@ const addLayer = async (map, landUseSlug="all", mainInterventionSlug, interventi
           }
 
           // We display a popup with the country's publications data
-          popup = new maplibregl.Popup({ closeButton: false })
+          popup = new maplibregl.Popup({ closeButton: false, offset: 40  })
             .setLngLat(cluster.geometry.coordinates)
             .setHTML(getHTMLPopup(cluster))
             .addTo(map);

--- a/javascript/map/map-layers.js
+++ b/javascript/map/map-layers.js
@@ -1,264 +1,165 @@
-const addLayer = (map, landUseSlug="all", mainInterventionSlug, interventionSlug, subTypeSlug) => {
-  const slug = landUseSlug === 'all'
-    ? landUseSlug
-    : [landUseSlug, mainInterventionSlug, interventionSlug, subTypeSlug].filter(Boolean).join('-');
-  const layerName = `layer-${slug}`;
-  const clusterLayerName = `clusters-${slug}`;
+const markers = [];
+let popup = null;
+let mapListener = null;
 
-  const currentLayers = map.getStyle()?.layers;
-  const currentSources = map.getStyle()?.sources;
+const getMarkerSizeClasses = (feature) => {
+  const countClassesTuples = [
+    [10, ['h-5', 'w-5']],
+    [500, ['h-10', 'w-10']],
+    [5000, ['h-[60px]', 'w-[60px]']],
+    [Infinity, ['h-20', 'w-20']],
+  ];
 
-  const isSourceDefined = !!currentSources[layerName];
-  const isLayerActive = currentLayers.some(l => l.id === layerName);
+  const count = feature.properties.number_primary_studies;
+  return countClassesTuples.find(([limit]) => count < limit)[1];
+}
 
-  // Get the layer and load it if not already loaded
-  if (!isSourceDefined || !isLayerActive) {
-    getLayer(landUseSlug, mainInterventionSlug, interventionSlug, subTypeSlug).then(layer => {
-      const countryValues = layer && Object.values(layer);
-      const features = countryValues && countryValues.map(country => {
-        const geom = country.geom && JSON.parse(country.geom)?.[0];
-        return ({
-          type: "Feature",
-          geometry: geom.geometry,
-          properties: {
-            number_primary_studies: country.number_primary_studies,
-            effect_outcomes: country.effect_outcomes,
-            country_name: geom?.properties?.long_name,
-            id: geom?.properties?.id,
-          }
-        }
-      )});
+const createHTMLMarker = (feature, isCluster, onClick) => {
+  const element = document.createElement('button');
+  element.type = 'button';
 
-      const geoJSONContent = {
-        type: 'FeatureCollection',
-        features,
-      };
+  const classes = [
+    'flex',
+    'items-center',
+    'justify-center',
+    'bg-mod-sc-ev',
+    ...getMarkerSizeClasses(feature),
+    ...(!isCluster ? ['border-2', 'border-gray-800'] : [])
+  ];
+  element.classList.add(...classes);
 
-      if (!isSourceDefined) {
-        // ADD SOURCE. SAME FOR CLUSTERS AND LAYER
-        map.addSource(layerName, {
-          'type': 'geojson',
-          'data': geoJSONContent,
-          cluster: true,
-          clusterMaxZoom: 14, // Max zoom to cluster points on
-          clusterRadius: 100, // Radius of each cluster when clustering points
-          clusterProperties: {
-            number_primary_studies: ['+', ['get', 'number_primary_studies']]
-          }
-        });
-      }
+  element.innerHTML = `
+    <div class="text-sm text-white">
+      ${formatNumber(feature.properties.number_primary_studies)}
+    </div>
+  `;
 
-      if (!isLayerActive) {
-        // ADD CLUSTERS
-        map.addLayer({
-          id: clusterLayerName,
-          type: 'symbol',
-          source: layerName,
-          filter: ['has', 'point_count'],
-          'layout': {
-            // The format must correspond to the one defined in `formatNumber` in
-            // `/javascript/utils.js`. For that we would use this line:
-            //
-            // 'text-field': ['number-format', ['get', 'number_primary_studies'], { locale: 'fr' }],
-            //
-            // Unfortunately, and for unknown reasons, the space between thousands, millions, etc.
-            // is not rendered. As a workaround, we're manually adding the spaces.
-            'text-field': [
-              'let',
-              'char_len', ['length', ['to-string', ['get', 'number_primary_studies']]],
-              'str', ['to-string', ['get', 'number_primary_studies']],
-              [
-                'case',
-                ['all', ['>=', ['var', 'char_len'], 7]],
-                [
-                  'concat',
-                  ['slice', ['var', 'str'], 0, ['-', ['var', 'char_len'], 6]],
-                  ' ',
-                  ['slice', ['var', 'str'], ['-', ['var', 'char_len'], 6], ['-', ['var', 'char_len'], 3]],
-                  ' ',
-                  ['slice', ['var', 'str'], ['-', ['var', 'char_len'], 3], ['var', 'char_len']],
-                ],
-                ['all', ['>=', ['var', 'char_len'], 4]],
-                [
-                  'concat',
-                  ['slice', ['var', 'str'], 0, ['-', ['var', 'char_len'], 3]],
-                  ' ',
-                  ['slice', ['var', 'str'], ['-', ['var', 'char_len'], 3], ['var', 'char_len']],
-                ],
-                ['var', 'str'],
-              ]
-            ],
-            'text-size': 16,
-            'text-font': ['Roboto Slab'],
-            'text-offset': [0, -0.5],
-            'text-anchor': 'top',
-            'icon-image': 'square',
-            'icon-size': [
-              'interpolate',
-              ['exponential', 2],
-              ['get', 'number_primary_studies'],
-              0, 0.8,
-              50000, 1.6
-            ],
-            // We need to allow overlap to avoid dissapearing clusters
-            'text-allow-overlap' : true,
-            'text-ignore-placement': true,
-            'icon-allow-overlap': true,
-            'icon-ignore-placement': true,
-          },
-          'paint': {
-            'text-color': '#3C4363',
-            'icon-color': [
-              'step',
-              ['get', 'number_primary_studies'],
-              '#B0F2BC',
-              100,
-              '#89E8AC',
-              500,
-              '#67DBA5',
-              1000,
-              '#4CC8A3',
-              5000,
-              '#2BB3A7'
-            ]
-          }
-        });
+  element.addEventListener('click', onClick);
 
-        // ADD LAYER
-        map.addLayer({
-          'id': layerName,
-          'source': layerName,
-          'type': 'symbol',
-          filter: ['!', ['has', 'point_count']],
-          'layout': {
-            // The format must correspond to the one defined in `formatNumber` in
-            // `/javascript/utils.js`. For that we would use this line:
-            //
-            // 'text-field': ['number-format', ['get', 'number_primary_studies'], { locale: 'fr' }],
-            //
-            // Unfortunately, and for unknown reasons, the space between thousands, millions, etc.
-            // is not rendered. As a workaround, we're manually adding the spaces.
-            'text-field': [
-              'let',
-              'char_len', ['length', ['to-string', ['get', 'number_primary_studies']]],
-              'str', ['to-string', ['get', 'number_primary_studies']],
-              [
-                'case',
-                ['all', ['>=', ['var', 'char_len'], 7]],
-                [
-                  'concat',
-                  ['slice', ['var', 'str'], 0, ['-', ['var', 'char_len'], 6]],
-                  ' ',
-                  ['slice', ['var', 'str'], ['-', ['var', 'char_len'], 6], ['-', ['var', 'char_len'], 3]],
-                  ' ',
-                  ['slice', ['var', 'str'], ['-', ['var', 'char_len'], 3], ['var', 'char_len']],
-                ],
-                ['all', ['>=', ['var', 'char_len'], 4]],
-                [
-                  'concat',
-                  ['slice', ['var', 'str'], 0, ['-', ['var', 'char_len'], 3]],
-                  ' ',
-                  ['slice', ['var', 'str'], ['-', ['var', 'char_len'], 3], ['var', 'char_len']],
-                ],
-                ['var', 'str'],
-              ]
-            ],
-            'text-size': 16,
-            'text-font': ['Roboto Slab'],
-            'text-offset': [0, -0.5],
-            'text-anchor': 'top',
-            'text-allow-overlap': true,
-            'text-ignore-placement': true,
-            'icon-image': 'square',
-            'icon-size': [
-              'interpolate',
-              ['exponential', 2],
-              ['get', 'number_primary_studies'],
-              0, 0.8,
-              50000, 1.6
-            ],
-            'icon-allow-overlap': true,
-            'icon-ignore-placement': true,
-          },
-          'paint': {
-            'text-color': '#fff',
-            'icon-color':"#3C4363"
-          }
-        });
+  return element;
+};
 
-        // Clusters zoom on click
-        map.on('click', clusterLayerName, (e) => {
-          const features = map.queryRenderedFeatures(e.point, {
-            layers: [clusterLayerName]
-          });
-          const clusterId = features[0].properties.cluster_id;
-          const leftPadding = elements.sidebar.getBoundingClientRect().right;
-          map.getSource(layerName).getClusterExpansionZoom(
-              clusterId,
-              (err, zoom) => {
-                  if (err) return;
+const getHTMLPopup = (feature) => {
+  const { country_name, number_primary_studies, effect_outcomes } = feature?.properties || {};
+  const outcomesList = Object.entries(effect_outcomes)
+    .sort((a, b) => b[1] - a[1])
+    .map(([key, value]) => (`
+      <span class="text-right">${formatNumber(value)}</span>
+      <span>${key}</span>
+    `)).join('');
 
-                  map.easeTo({
-                      center: features[0].geometry.coordinates,
-                      zoom,
-                      padding: { left: leftPadding }
-                  });
-              }
-          );
-        });
+  return `
+    <div class="space-y-4">
+      <h4 class="text-slate-700 text-xl font-semibold font-serif leading-[30px]">
+        ${country_name}
+      </h4>
+      <button type="button" id="popup-close-button" class="absolute right-4 top-4 !m-0">
+        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+          stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="h-6 w-6">
+          <path d="M18 6 6 18"></path>
+          <path d="m6 6 12 12"></path>
+        </svg>
+        <span class="sr-only">Close</span>
+      </button>
+      <div class="max-h-[140px] overflow-y-auto overflow-x-hidden">
+        <div class="grid grid-cols-[min-content_1fr] auto-rows-auto gap-x-2 w-full">
+          <span class="mb-3">${formatNumber(number_primary_studies)}</span>
+          <span class="mb-3">total</span>
+          ${outcomesList}
+        </div>
+      </div>
+    </div>
+  `;
+};
 
-        // ADD TOOLTIP
-        map.on('click', layerName, (event) => {
-          const feature = event.features?.[0];
-          const { country_name, number_primary_studies, effect_outcomes } = feature?.properties || {};
-          const parsedEffectOutcomes = effect_outcomes && JSON.parse(effect_outcomes);
-          const outcomesList = Object.entries(parsedEffectOutcomes)
-            .sort((a, b) => b[1] - a[1])
-            .map(([key, value]) => (`
-              <span class="text-right">${formatNumber(value)}</span>
-              <span>${key}</span>
-            `)).join('');
-
-          const tooltipHTML = `
-            <div class="space-y-4">
-              <h4 class="text-slate-700 text-xl font-semibold font-serif leading-[30px]">
-                ${country_name}
-              </h4>
-              <button type="button" id="popup-close-button" class="absolute right-4 top-4 !m-0">
-                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor"
-                  stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="h-6 w-6">
-                  <path d="M18 6 6 18"></path>
-                  <path d="m6 6 12 12"></path>
-                </svg>
-              </button>
-              <div class="max-h-[140px] overflow-y-auto overflow-x-hidden">
-                <div class="grid grid-cols-[min-content_1fr] auto-rows-auto gap-x-2 w-full">
-                  <span class="mb-3">${formatNumber(number_primary_studies)}</span>
-                  <span class="mb-3">total</span>
-                  ${outcomesList}
-                </div>
-              </div>
-            </div>`
-
-            const popup = new maplibregl.Popup({ closeButton: false })
-              .setLngLat(feature.geometry.coordinates)
-              .setHTML(tooltipHTML)
-              .addTo(map);
-
-            document.getElementById('popup-close-button').addEventListener("click", () => popup.remove());
-        })
-      }
-    });
+const addLayer = async (map, landUseSlug="all", mainInterventionSlug, interventionSlug, subTypeSlug) => {
+  // Remove the previous listeners from the map
+  if (mapListener) {
+    map.off('move', mapListener);
+    map.off('moveend', mapListener);
+    mapListener = null;
   }
 
-  currentLayers.forEach(({ id }) => {
-    if (id === layerName || id === clusterLayerName) {
-      map.setLayoutProperty(id, 'visibility', 'visible');
-    } else if (
-      id.startsWith('layer-') && id !== layerName ||
-      id.startsWith('clusters-') && id !== clusterLayerName
-    ) {
-      map.setLayoutProperty(id, 'visibility', 'none');
+  const layerData = await getLayer(landUseSlug, mainInterventionSlug, interventionSlug, subTypeSlug);
+  const features = Object.values(layerData ?? {}).map(country => {
+    const geom = country.geom && JSON.parse(country.geom)?.[0];
+    return ({
+      type: "Feature",
+      geometry: geom.geometry,
+      properties: {
+        number_primary_studies: country.number_primary_studies,
+        effect_outcomes: country.effect_outcomes,
+        country_name: geom?.properties?.long_name,
+        id: geom?.properties?.id,
+      }
     }
-  });
+  )});
+
+  // The clustering depends on the map's current position and zoom level
+  mapListener = () => {
+    // Remove all the markers from the map
+    markers.forEach((marker) => {
+      marker.remove();
+    });
+  
+    markers.length = 0;
+
+    const bbox = map.getBounds().toArray().flat();
+    const zoom = map.getZoom();
+    
+    const supercluster = new Supercluster({
+      radius: 100,
+      reduce: (res, { number_primary_studies }) => {
+        res.number_primary_studies += number_primary_studies;
+      },
+    }).load(features);
+    const clusters = supercluster.getClusters(bbox, zoom);
+
+    clusters.map((cluster) => {
+      const isCluster = cluster.properties.cluster;
+
+      const onClickMarker = (e) => {
+        e.stopPropagation();
+
+        if (isCluster) {
+          // We zoom to expand the cluster
+          const targetZoom = supercluster.getClusterExpansionZoom(cluster.properties.cluster_id);
+          map.flyTo({
+            center: cluster.geometry.coordinates,
+            zoom: targetZoom,
+          });
+        } else {
+          // We remove the eventual popup
+          if (popup) {
+            popup.remove();
+            popup = null;
+          }
+
+          // We display a popup with the country's publications data
+          popup = new maplibregl.Popup({ closeButton: false })
+            .setLngLat(cluster.geometry.coordinates)
+            .setHTML(getHTMLPopup(cluster))
+            .addTo(map);
+
+          document.getElementById('popup-close-button').addEventListener("click", () => {
+            popup.remove();
+            popup = null;
+          });
+        }
+      };
+
+      const marker = new maplibregl.Marker({
+        element: createHTMLMarker(cluster, isCluster, onClickMarker)
+      }).setLngLat(cluster.geometry.coordinates)
+        .addTo(map);
+
+      markers.push(marker);
+    });
+  };
+
+  // Add the listener to recompute the clusters and execute it once to render the initial view
+  map.on('move', mapListener);
+  map.on('moveend', mapListener);
+
+  mapListener();
 };

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -22,11 +22,6 @@ tailwind.config = {
         'mod-sc-ev-light': '#CEEEE3',
         'chart-color': '#B4E4D7',
         'mod-sc-ev-dark': '#1E6B65',
-        'cluster-100': '#B0F2BC',
-        'cluster-200': '#89E8AC',
-        'cluster-300': '#67DBA5',
-        'cluster-400': '#4CC8A3',
-        'cluster-500': '#2BB3A7',
         brown: {
           // Practices
           500: '#BA7300',


### PR DESCRIPTION
This PR updates the styles of the clusters/markers, the popups and the legend.

Based on the designs, the title of the popups should be « [Country]'s publications » but it doesn't look nice with some of the countries such as “Congo (Democratic Republic of the)”. For this reason, I decided to use the following title: « Publications is [Country]». This isn't a perfect solution, especially for countries such as “United States” or  “United Kingdom” but I still think it's better.

## Acceptance criteria

- The clusters on the map:
  - Use the same shade of green
  - Use the Roboto font (sans serif)
  - Have a different size depending on the number of publications they represent
- The country markers on the map:
  - Use the same shade of green
  - Have a dark blue border
  - Use the Roboto font (sans serif)
  - Have a different size depending on the number of publications they represent
- The legend explains the size of the markers and the shows the difference between clusters and country markers
  - The button to expand/contracts the legend is in plain text

## Tracking

[ORC-270](https://vizzuality.atlassian.net/browse/ORC-270)