### PR TITLE
Limit the maximum map's zoom to 12

### DIFF
--- a/javascript/map/map.js
+++ b/javascript/map/map.js
@@ -9,7 +9,7 @@ const map = new maplibregl.Map({
   // default i.e. less of the Antarctica is shown
   bounds: [-180, -80, 180, 90],
   minZoom: 1,
-  maxZoom: 20,
+  maxZoom: 12,
 });
 
 // Set the default padding


### PR DESCRIPTION
This PR limits the maximum map's zoom to 12.

## Acceptance criteria

- The visitor can zoom the map up to level 12
  - Applies to all the modules (including Scientific Evidence)

## Tracking

[ORC-465](https://vizzuality.atlassian.net/browse/ORC-465)

[ORC-465]: https://vizzuality.atlassian.net/browse/ORC-465?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ