### PR TITLE
Fix the position of filters on desktop

### DIFF
--- a/index.html
+++ b/index.html
@@ -609,7 +609,7 @@
                 </span>
               </button>
               <fieldset
-                class="flex flex-col hidden absolute z-30 rounded-lg border-none shadow bg-gray-650 overflow-auto w-full min-h-[100px]"
+                class="dropdown-options hidden"
                 id="land-use-dropdown-options-filters">
               </fieldset>
             </div>
@@ -633,7 +633,7 @@
                 </span>
               </button>
               <fieldset
-                class="flex flex-col hidden absolute z-30 rounded-lg border-none shadow bg-gray-650 overflow-auto w-full min-h-[100px]"
+                class="dropdown-options hidden"
                 id="main-intervention-dropdown-options-filters">
               </fieldset>
             </div>
@@ -657,7 +657,7 @@
                 </span>
               </button>
               <fieldset
-                class="flex flex-col hidden absolute z-30 rounded-lg border-none shadow bg-gray-650 overflow-auto w-full min-h-[100px]"
+                class="dropdown-options hidden"
                 id="intervention-dropdown-options-filters">
               </fieldset>
             </div>
@@ -681,7 +681,7 @@
                 </span>
               </button>
               <fieldset
-                class="flex flex-col hidden absolute z-30 rounded-lg border-none shadow bg-gray-650 overflow-auto w-full min-h-[100px]"
+                class="dropdown-options hidden"
                 id="sub-type-dropdown-options-filters">
               </fieldset>
             </div>

--- a/javascript/dynamic-data.js
+++ b/javascript/dynamic-data.js
@@ -216,18 +216,43 @@ const initSelectActions = ({ filters = false, select } = {}) => {
   const selectButton = selectElements[filters ? 'filters' : 'main'][select].selectButton;
   const selectOptions = selectElements[filters ? 'filters' : 'main'][select].selectOptions;
 
+  // Store the popper of the last opened filter
+  let popper = null;
+
+  const toggleSelect = () => {
+    if (popper) {
+      // Without this line, the position of the popper is incorrect
+      popper.destroy();
+    }
+
+    popper = Popper.createPopper(selectButton, selectOptions, {
+      modifiers: [
+        {
+          name: 'offset',
+          options: {
+            offset: [0, 8],
+          },
+        },
+      ],
+    });
+
+    selectOptions.classList.toggle('hidden');
+
+    if (!selectOptions.classList.contains('hidden') && options && options.length > 0) {
+      options[0].focus();
+    }
+  }
+
   // Close on click outside
   document.addEventListener('click', function(event) {
-    if (!selectOptions.contains(event.target) && !selectButton.contains(event.target)) {
-      selectOptions.classList.add('hidden');
+    const isOpen = !selectOptions.classList.contains('hidden');
+    if (isOpen && !selectOptions.contains(event.target) && !selectButton.contains(event.target)) {
+      toggleSelect();
     }
   });
 
   selectButton.addEventListener('click', function() {
-    selectOptions.classList.toggle('hidden');
-    if (options && options.length > 0) {
-      options[0].focus();
-    }
+    toggleSelect();
   });
 
   selectButton.addEventListener('keydown', function(event) {

--- a/javascript/event-listeners.js
+++ b/javascript/event-listeners.js
@@ -419,17 +419,6 @@ window.addEventListener('load', function () {
     const selectedLandUseLabel = selectedLandUse.name;
     elements.landUseSelectFiltersButton.innerHTML = selectedLandUseLabel;
 
-    Popper.createPopper(elements.landUseSelectFiltersButton, landUseMenuFilters, {
-      modifiers: [
-        {
-          name: 'offset',
-          options: {
-            offset: [0, 8],
-          },
-        },
-      ],
-    });
-
     // Initialize event listeners if they were not already initialized
     if (!window.getters.landUseSelectActionsInitialized()) {
       initSelectActions({ filters: true, select: 'landUse' });
@@ -497,17 +486,6 @@ window.addEventListener('load', function () {
       setAllMainInterventionOption();
     }
 
-    Popper.createPopper(elements.mainInterventionSelectFiltersButton, elements.mainInterventionOptionsFilters, {
-      modifiers: [
-        {
-          name: 'offset',
-          options: {
-            offset: [0, 8],
-          },
-        },
-      ],
-    });
-
     // Initialize event listeners if they were not already initialized
     if (!window.getters.mainInterventionSelectActionsInitialized()) {
       initSelectActions({ filters: true, select: 'mainIntervention'});
@@ -530,17 +508,6 @@ window.addEventListener('load', function () {
       });
       elements.interventionSelectFilters.classList.remove('lg:hidden');
     }
-
-    Popper.createPopper(elements.interventionSelectFiltersButton, elements.interventionOptionsFilters, {
-      modifiers: [
-        {
-          name: 'offset',
-          options: {
-            offset: [0, 8],
-          },
-        },
-      ],
-    });
 
     // Initialize event listeners if they were not already initialized
     if (!window.getters.interventionSelectActionsInitialized()) {
@@ -566,17 +533,6 @@ window.addEventListener('load', function () {
       });
       elements.subTypeSelectFilters.classList.remove('lg:hidden');
     }
-
-    Popper.createPopper(elements.subTypeSelectFiltersButton, elements.subTypeOptionsFilters, {
-      modifiers: [
-        {
-          name: 'offset',
-          options: {
-            offset: [0, 8],
-          },
-        },
-      ],
-    });
 
     // Initialize event listeners if they were not already initialized
     if (!window.getters.subTypeSelectActionsInitialized()) {


### PR DESCRIPTION
This PR fixes the position of the Land use, Main intervention, Intervention and Sub-type filters on desktop.

## Testing instructions

Open each of the filters multiple times and make sure the dropdowns are visible.