### PR TITLE
Reset map when we reset the filters and repopulate dropdowns

### DIFF
--- a/javascript/event-listeners.js
+++ b/javascript/event-listeners.js
@@ -1029,7 +1029,9 @@ window.addEventListener('load', function () {
       window.mutations.setFilter(null);
       resetMainInterventionSelect();
 
-      window.reloadPublications();
+      window.loadPublications();
+      // Reset map layer
+      addDataLayer(map, 'all');
 
       // Reset the active filters badge
       window.mutations.setActiveFilters([]);


### PR DESCRIPTION
Publications - Map was not reseting the layer when we clicked on 'Reset all'
Now we can see the changes
