### PR TITLE
Add back the land use type in sentence at the top of the results

### DIFF
--- a/javascript/dynamic-data.js
+++ b/javascript/dynamic-data.js
@@ -1077,7 +1077,11 @@ window.addEventListener('load', function () {
   const updateNumbers = (metadata) => {
     const { totalPublications, totalMetaAnalysis } = metadata;
 
-    elements.resultsSentence.innerHTML = `Showing ${totalMetaAnalysis ? formatNumber(totalMetaAnalysis) : 0} meta-analyses and ${totalPublications ? formatNumber(totalPublications) : 0} primary studies.`;
+    const landUsesData = window.getters.landUses();
+    const landUseSlug = window.getters.landUse();
+    const landUse = landUsesData.find(({ slug }) => slug === landUseSlug);
+
+    elements.resultsSentence.innerHTML = `Showing ${totalMetaAnalysis ? formatNumber(totalMetaAnalysis) : 0} meta-analyses and ${totalPublications ? formatNumber(totalPublications) : 0} primary studies${landUseSlug === 'all' ? '.' : ` related to <span class="font-bold">${landUse?.name ?? '−'}</span>.`}`;
   };
 
   const populateYearChart = (years) => {


### PR DESCRIPTION
This PR adds back the land use type in the sentence at the top of the publication results.

## Acceptance criteria

- The sentence at the top of the publications list reads:« Showing [XXX] meta-analyses and [YYY] primary studies related to [ZZZ]. », where ZZZ is the name of the land use type displayed in bold

## Tracking

[ORC-702](https://vizzuality.atlassian.net/browse/ORC-702)

[ORC-702]: https://vizzuality.atlassian.net/browse/ORC-702?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ