### PR TITLE
Break words not fitting in the table of the meta-analysis detailed view

### DIFF
--- a/javascript/dynamic-data.js
+++ b/javascript/dynamic-data.js
@@ -40,7 +40,7 @@ const methodologyAndAttributesTemplate = (methodologyAndAttributes) => {
 
     return `<div class="flex justify-between items-center border border-b border-main divide-x divide-main">
       <span class="text-neutral-300 text-xs py-4 px-6">${label}</span>
-      <span class="text-white flex items-center justify-center text-xs leading-7 px-6 py-4 w-[128px] shrink-0">${renderValue(value)}</span>
+      <span class="text-white flex items-center justify-center text-xs leading-7 px-6 py-4 w-[128px] shrink-0 break-all">${renderValue(value)}</span>
     </div>`;
   }).join('');
 

--- a/javascript/dynamic-data.js
+++ b/javascript/dynamic-data.js
@@ -35,12 +35,12 @@ const methodologyAndAttributesTemplate = (methodologyAndAttributes) => {
       if (value === '-') {
         return '<img src="/assets/icons/blank.svg" alt="no icon" class="w-6 h-6" />';
       }
-      return `<span class="pr-2">${value}</span>`;
+      return `<span class="pr-2 w-full break-words">${value}</span>`;
     };
 
     return `<div class="flex justify-between items-center border border-b border-main divide-x divide-main">
       <span class="text-neutral-300 text-xs py-4 px-6">${label}</span>
-      <span class="text-white flex items-center justify-center text-xs leading-7 px-6 py-4 w-[128px] shrink-0 break-all">${renderValue(value)}</span>
+      <span class="text-white flex items-center justify-center text-xs leading-7 px-6 py-4 w-[128px] shrink-0">${renderValue(value)}</span>
     </div>`;
   }).join('');
 


### PR DESCRIPTION
This PR makes sure that words are broken to a new lines if they don't fit in the table displayed in the detailed view of a meta-analysis.

## Acceptance criteria

On the detailed view of a meta-analysis:

- The values in the table fit within their cell

## Tracking

[ORC-713](https://vizzuality.atlassian.net/browse/ORC-713)

[ORC-713]: https://vizzuality.atlassian.net/browse/ORC-713?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ