### PR TITLE
Reset active filters on back button from publicaitons

### DIFF
--- a/javascript/dynamic-data.js
+++ b/javascript/dynamic-data.js
@@ -279,6 +279,10 @@ const initSelectActions = ({ filters = false, select } = {}) => {
     if (select === 'landUse') {
       window.mutations.setLandUse(slug);
       window.mutations.setFilter(null);
+
+      // Reset filters when we select a new land use
+      window.resetPublicationsFilters();
+
       loadData(slug);
       // Load also map data only if we change the land use
       addDataLayer(map, slug);
@@ -1061,6 +1065,9 @@ window.addEventListener('load', function () {
 
         window.mutations.setLandUse(selected);
         loadData(selected);
+
+        // Reset the other filters filters when we select a new land use
+        window.resetPublicationsFilters();
 
         // Load publications instead of reload to repopulate the filters
         window.loadPublications();

--- a/javascript/event-listeners.js
+++ b/javascript/event-listeners.js
@@ -51,7 +51,7 @@ window.recalculateActiveFilters = (dropdownId, options) => {
 
 window.addEventListener('load', function () {
   // SHARED CODE
-  const resetPublicationsFilters = () => {
+  window.resetPublicationsFilters = () => {
     for (let dropdown of isMobile() ? elements.mobileDropdowns : elements.dropdowns) {
       const selected = dropdown.querySelector('.dropdown-selected');
       const options = dropdown.querySelector('.dropdown-options');
@@ -773,7 +773,7 @@ window.addEventListener('load', function () {
 
   elements.closePublicationPanelButton.addEventListener("click", function() {
     // We reset the whole publications view without reloading the publications
-    resetPublicationsFilters();
+    window.resetPublicationsFilters();
     resetPublicationsSort();
     // We reset the pagination
     window.mutations.setPublicationPage(1);
@@ -1034,7 +1034,7 @@ window.addEventListener('load', function () {
   // RESET FILTERS
   if(!(elements.resetFiltersButton._eventListeners?.click)) {
     elements.resetFiltersButton.addEventListener('click', () => {
-      resetPublicationsFilters();
+      window.resetPublicationsFilters();
 
       window.mutations.setLandUse('all');
       // Reset land use select
@@ -1068,7 +1068,7 @@ window.addEventListener('load', function () {
   // RESET FILTERS MOBILE
   if(!(elements.resetFiltersMobileButton._eventListeners?.click)) {
     elements.resetFiltersMobileButton.addEventListener('click', () => {
-      resetPublicationsFilters();
+      window.resetPublicationsFilters();
       window.mutations.setLandUse('all');
       window.mutations.setFilter(null);
       // Select the all button on the land use select

--- a/javascript/event-listeners.js
+++ b/javascript/event-listeners.js
@@ -69,6 +69,8 @@ window.addEventListener('load', function () {
 
     window.mutations.setSearch('');
     elements.search.querySelector('input').value = '';
+
+    window.mutations.setActiveFilters([]);
   };
 
   const resetPublicationsSort = () => {


### PR DESCRIPTION
Publication filter count on badge was not reseting after going back to home page

https://vizzuality.atlassian.net/browse/ORC-716

- I select All / Publications : Filter / Year = 1910

- Then I go back to the homepage of scientific evidence, I select “Other land” / Publications / Filter

- I can see that 2 filters are still selected on the left and one on the right: